### PR TITLE
Trying to customize package display for WET

### DIFF
--- a/ckanext/virtual_library/templates/scheming/display_snippets/fluent_text.html
+++ b/ckanext/virtual_library/templates/scheming/display_snippets/fluent_text.html
@@ -1,0 +1,11 @@
+{%- set values = data[field.field_name] -%}
+
+{%- if  h.lang() in values -%}
+  {{ values[h.lang()] }}
+{%- else -%}
+  {%- for lang in values -%}
+    {%- if lang not in field.form_languages -%}
+      {{ values[lang] }}
+    {%- endif -%}
+  {%- endfor -%}
+{%- endif -%}

--- a/ckanext/virtual_library/templates/scheming/package/snippets/additional_info.html
+++ b/ckanext/virtual_library/templates/scheming/package/snippets/additional_info.html
@@ -1,0 +1,31 @@
+{% ckan_extends %}
+
+{%- set exclude_fields = [
+    'title', 
+    'name',
+    'notes',
+    'tag_string',
+    'license_id',
+    'owner_org',
+    ] -%}
+
+{% block package_additional_info %}
+  {%- for field in schema.dataset_fields -%}
+    {%- if field.field_name not in exclude_fields -%}
+      <tr>
+        <td><strong>{{
+          h.scheming_language_text(field.label) }}</strong></td>
+        <td {%
+          if field.display_property %} property="{{ field.display_properlty
+          }}"{% endif %}>{%- snippet 'scheming/snippets/display_field.html',
+          field=field, data=pkg_dict -%}</td>
+      </tr>
+    {%- endif -%}
+  {%- endfor -%}
+  {% if h.check_access('package_update',{'id':pkg_dict.id}) %}
+    <tr>
+      <td>{{ _("State") }}</td>
+      <td>{{ pkg_dict.state }}</td>
+    </tr>
+  {% endif %}
+{% endblock %}


### PR DESCRIPTION
I replaced  the additional_info.html snippet because I wanted to customize the formatting from the scheming extension. There is probably a cleaner way to do this.
